### PR TITLE
CASMHMS-5423 Build hms-discovery with GitHub Actions

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2022-05-05
+
+### Changed
+
+- CASMHMS-5423: Bump hms-discovery version to 1.11.0 for GitHub Actions transition.
+
 ## [2.0.1] - 2021-11-30
 
 ### Changed

--- a/charts/v2.0/cray-hms-discovery/Chart.yaml
+++ b/charts/v2.0/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 2.0.1
+version: 2.0.2
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.10.0"
+appVersion: "1.11.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-discovery/values.yaml
+++ b/charts/v2.0/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.10.0
+  appVersion: 1.11.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -11,6 +11,7 @@ chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "1.9.0"
   "2.0.1": "1.10.0"
+  "2.0.2": "1.11.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR includes the following changes:

- Update hms-discovery to build using GitHub Actions instead of Jenkins
- Pull images from algol60 Artifactory instead of arti.dev.cray.com
- Update Alpine base image version

### Issues and Related PRs

* Resolves CASMHMS-5423.
* Resolves CASMHMS-5411.

### Testing

This change was tested by verifying that the new hms-discovery version was built successfully using GitHub Actions and the resulting image was pushed to algol60 Artifactory. The newly built hms-discovery was also spun up locally in a docker-compose environment. No unit, integration, or CT tests to run for hms-discovery.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, only changing how hms-discovery is built and where images that it depends on are pulled from.