### PR TITLE
Change HSM v1 API References to v2 hms-discovery

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2022-07-06
+
+### Changed
+
+- CASMHMS-5609: Bump hms-discovery version to 1.12.0 for changing HSM v1 API references to v2.
+
 ## [2.0.2] - 2022-05-05
 
 ### Changed

--- a/charts/v2.0/cray-hms-discovery/Chart.yaml
+++ b/charts/v2.0/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 2.0.2
+version: 2.0.3
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.11.0"
+appVersion: "1.12.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-discovery/values.yaml
+++ b/charts/v2.0/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.11.0
+  appVersion: 1.12.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -12,6 +12,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "1.9.0"
   "2.0.1": "1.10.0"
   "2.0.2": "1.11.0"
+  "2.0.3": "1.12.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Changed HSM v1 API references to v2 in hms-discovery. Updated hms-dns-dhcp library used to support HSM v2.

## Issues and Related PRs

* Resolves [CASMHMS-5609](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5609)

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable