### PR TITLE
CASMHMS-5613: Pull in newer hms-discovery image

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.4] - 2022-07-28
+
+### Changed
+
+- CASMHMS-5613: Bump hms-discovery version to 1.13.0 for changes that remove the hardcode for the HSM, SLS, and CAPMC endpoints used the embedded mountain discovery script. 
+
 ## [2.0.3] - 2022-07-06
 
 ### Changed

--- a/charts/v2.0/cray-hms-discovery/Chart.yaml
+++ b/charts/v2.0/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 2.0.3
+version: 2.0.4
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.12.0"
+appVersion: "1.13.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-discovery/values.yaml
+++ b/charts/v2.0/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.12.0
+  appVersion: 1.13.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -13,6 +13,7 @@ chartVersionToApplicationVersion:
   "2.0.1": "1.10.0"
   "2.0.2": "1.11.0"
   "2.0.3": "1.12.0"
+  "2.0.4": "1.13.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Bump hms-discovery version to 1.13.0 for changes that remove the hardcode for the HSM, SLS, and CAPMC endpoints used the embedded mountain discovery script. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5613


## Testing

For testing see: https://github.com/Cray-HPE/hms-discovery/pull/31


## Risks and Mitigations
Low risk.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable