### PR TITLE
CASMHMS-5631 Update hms-mountain-discovery image to v0.7.0.

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.5] - 2022-08-01
+
+### Changed
+
+- Bump hms-discovery version to 1.14.0 which uses hms-mountain-discovery version 0.7.0 that is built with GitHub Actions.
+
 ## [2.0.4] - 2022-07-28
 
 ### Changed

--- a/charts/v2.0/cray-hms-discovery/Chart.yaml
+++ b/charts/v2.0/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 2.0.4
+version: 2.0.5
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.13.0"
+appVersion: "1.14.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-discovery/values.yaml
+++ b/charts/v2.0/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.13.0
+  appVersion: 1.14.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -14,6 +14,7 @@ chartVersionToApplicationVersion:
   "2.0.2": "1.11.0"
   "2.0.3": "1.12.0"
   "2.0.4": "1.13.0"
+  "2.0.5": "1.14.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR updates hms-discovery to use the hms-mountain-discovery:0.7.0 image which includes the following changes:

- Updated hms-mountain-discovery to build using GitHub Actions instead of Jenkins.
- Pull images from artifactory.algol60.net instead of arti.dev.cray.com.
- Updated Alpine base image version.
- Updated and fixed runUnitTest.sh.

### Issues and Related PRs

* Resolves CASMHMS-5631.

### Testing

This change was tested by verifying that the new hms-mountain-discovery version was built successfully using GitHub Actions and the resulting image was pushed to the expected location in Algol60 Artifactory. The newly built hms-mountain-discovery was also spun up locally in a docker-compose environment. No integration or CT tests to run for hms-mountain-discovery or hms-discovery.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk.