### PR TITLE
Updated API versions for k8s deprecated APIs

### DIFF
--- a/changelog/v2.1.md
+++ b/changelog/v2.1.md
@@ -1,0 +1,12 @@
+# Changelog for v2.1
+
+All notable changes to this project for v2.0.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.1.0] - 2023-01-10
+
+### Changed
+
+- Changed CronJob apiVersion to batch/v1

--- a/charts/v2.1/cray-hms-discovery/.gitignore
+++ b/charts/v2.1/cray-hms-discovery/.gitignore
@@ -1,0 +1,5 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*
+helm/*
+# Ignore also any built charts
+*.tgz

--- a/charts/v2.1/cray-hms-discovery/Chart.yaml
+++ b/charts/v2.1/cray-hms-discovery/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: "cray-hms-discovery"
+version: 2.1.0
+description: "Kubernetes resources for cray-hms-discovery"
+home: "https://github.com/Cray-HPE/hms-discovery-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-discovery"
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.14.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v2.1/cray-hms-discovery/templates/cronjob.yaml
+++ b/charts/v2.1/cray-hms-discovery/templates/cronjob.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hms-discovery
+  labels:
+    app: hms-discovery
+spec:
+  suspend: false
+  schedule: "*/3 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 10
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            app: hms-discovery
+            cronjob-name: hms-discovery
+        spec:
+          containers:
+            - name: hms-discovery
+              image: {{ .Values.image.repository }}:{{ default .Values.global.appVersion .Values.image.tag }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: SLS_URL
+                  value: "http://cray-sls"
+                - name: HSM_URL
+                  value: "http://cray-smd"
+                - name: DISCOVER_RIVER
+                  value: "true"
+                - name: DISCOVER_MOUNTAIN
+                  value: "true"
+                - name: BOOT_NEW_RIVER_NODES
+                  value: "false"
+
+                - name: VAULT_ADDR
+                  value: "http://cray-vault.vault:8200"
+                - name: VAULT_SKIP_VERIFY
+                  value: "true"
+                - name: VAULT_BASE_PATH
+                  value: "secret"
+              securityContext:
+                runAsUser: 65534
+                runAsGroup: 65534
+                runAsNonRoot: true
+          restartPolicy: Never

--- a/charts/v2.1/cray-hms-discovery/values.yaml
+++ b/charts/v2.1/cray-hms-discovery/values.yaml
@@ -1,0 +1,8 @@
+---
+
+global:
+  appVersion: 1.14.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/hms-discovery
+  pullPolicy: IfNotPresent

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -3,6 +3,7 @@
 chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
+  ">=2.1.0": "~1.2.0"
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -15,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.0.3": "1.12.0"
   "2.0.4": "1.13.0"
   "2.0.5": "1.14.0"
+  "2.1.0": "1.14.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Updated the CronJob version fro batch/v1beta1 to batch/v1. This fixes a deprecated api in k8s 1.22.

Here is the diff between v2.0 and v2.1
```
shunr@fedora> diff -r charts/v2.0/ charts/v2.1/
diff -r charts/v2.0/cray-hms-discovery/Chart.yaml charts/v2.1/cray-hms-discovery/Chart.yaml
3c3
< version: 2.0.5
---
> version: 2.1.0
diff -r charts/v2.0/cray-hms-discovery/templates/cronjob.yaml charts/v2.1/cray-hms-discovery/templates/cronjob.yaml
1c1
< apiVersion: batch/v1beta1
---
> apiVersion: batch/v1
```

The branch `fix-k8s-deprecation-casmhms-5878-test` contains these changes and changes for a workflow that detects k8s api deprecations.

- Here are results before the fix: https://github.com/Cray-HPE/hms-discovery-charts/actions/runs/3896224653
- Here are the results after: https://github.com/Cray-HPE/hms-discovery-charts/actions/runs/3896264667

## Issues and Related PRs

* Resolves [CASMHMS-5878](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5878)

## Testing

Tested on:

  * mug

Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

low, other charts are already using the CronJob version.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable