### PR TITLE
Changed to not write the default creds when there are already creds

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -5,6 +5,11 @@ All notable changes to this project for v3.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2024-02-08
+
+### Changed
+- Changed to not write the default credentials when there are already credentials in vault.
+
 ## [3.0.0] - 2023-09-25
 
 ### Added

--- a/charts/v3.0/cray-hms-discovery/Chart.yaml
+++ b/charts/v3.0/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 3.0.0
+version: 3.0.1
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.15.0"
+appVersion: "1.16.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-discovery/values.yaml
+++ b/charts/v3.0/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.15.0
+  appVersion: 1.16.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -20,6 +20,7 @@ chartVersionToApplicationVersion:
   "2.1.0": "1.14.0"
   "2.1.1": "1.14.1"
   "3.0.0": "1.15.0"
+  "3.0.1": "1.16.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION


## Summary and Scope

Changed to not write the default creds when there are already creds

Adopted app version 1.14.1

CASMHMS-6129

## Issues and Related PRs

* Resolves [CASMHMS-6129](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6129)

## Testing

_List the environments in which these changes were tested._

Tested on:

  * tyr
  * Local development environment

Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable