### PR TITLE
CASMHMS-6412: Update image and module dependencies for security updates

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -1,0 +1,15 @@
+# Changelog for v3.1
+
+All notable changes to this project for v3.1.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.1.0] - 2025-03-13
+
+### Security
+
+- Updated image and module dependencies for security updates
+- Various code changes to accomodate module updates
+- Resolved build warnings in Dockerfiles and docker compose files
+

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -12,4 +12,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated image and module dependencies for security updates
 - Various code changes to accomodate module updates
 - Resolved build warnings in Dockerfiles and docker compose files
-
+- Fixed docker-compose.devel.yaml file so that local dev testing works again
+- Updated local dev testing readme for accuracy

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,12 +5,11 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.0] - 2025-03-13
+## [3.1.0] - 2025-03-14
 
 ### Security
 
 - Updated image and module dependencies for security updates
 - Various code changes to accomodate module updates
-- Resolved build warnings in Dockerfiles and docker compose files
 - Fixed docker-compose.devel.yaml file so that local dev testing works again
 - Updated local dev testing readme for accuracy

--- a/charts/v3.1/cray-hms-discovery/.gitignore
+++ b/charts/v3.1/cray-hms-discovery/.gitignore
@@ -1,0 +1,5 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*
+helm/*
+# Ignore also any built charts
+*.tgz

--- a/charts/v3.1/cray-hms-discovery/Chart.yaml
+++ b/charts/v3.1/cray-hms-discovery/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: "cray-hms-discovery"
+version: 3.1.0
+description: "Kubernetes resources for cray-hms-discovery"
+home: "https://github.com/Cray-HPE/hms-discovery-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-discovery"
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.18.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-discovery/templates/cronjob.yaml
+++ b/charts/v3.1/cray-hms-discovery/templates/cronjob.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hms-discovery
+  labels:
+    app: hms-discovery
+spec:
+  suspend: false
+  schedule: "*/3 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 10
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            app: hms-discovery
+            cronjob-name: hms-discovery
+        spec:
+          containers:
+            - name: hms-discovery
+              image: {{ .Values.image.repository }}:{{ default .Values.global.appVersion .Values.image.tag }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: LOG_LEVEL
+                  value: {{ .Values.discovery.logLevel | quote }}
+
+                - name: SLS_URL
+                  value: "http://cray-sls"
+                - name: HSM_URL
+                  value: "http://cray-smd"
+
+                - name: DISCOVER_RIVER
+                  value: {{ .Values.discovery.discoverRiverWithDHCP | quote }}
+                - name: DISCOVER_MOUNTAIN
+                  value: {{ .Values.discovery.discoverMountain | quote }}
+                - name: DISCOVER_MANAGEMENT_NODES
+                  value: {{ .Values.discovery.discoverManagementNodes | quote }}
+                - name: DISCOVER_MANAGEMENT_VIRTUAL_NODES
+                  value: {{ .Values.discovery.discoverManagementVirtualNodes | quote }}
+                - name: REDISCOVER_FAILED_REDFISH_ENDPOINTS
+                  value: {{ .Values.discovery.rediscoverFailedRedfishEndpoints | quote }}
+                - name: POPULATE_MANAGEMENT_SWITCH_CREDENTIALS
+                  value: {{ .Values.discovery.populateManagementSwitchCredentials | quote }}
+
+                - name: VAULT_ADDR
+                  value: "http://cray-vault.vault:8200"
+                - name: VAULT_SKIP_VERIFY
+                  value: "true"
+                - name: VAULT_BASE_PATH
+                  value: "secret"
+              securityContext:
+                runAsUser: 65534
+                runAsGroup: 65534
+                runAsNonRoot: true
+          restartPolicy: Never

--- a/charts/v3.1/cray-hms-discovery/templates/jobs.yaml
+++ b/charts/v3.1/cray-hms-discovery/templates/jobs.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.vaultLoader.enabled }}
+---
+apiVersion: batch/v1
+kind:       Job
+metadata:
+  name: hms-discovery-vault-loader-{{ .Release.Revision }}
+  labels:
+    app: hms-discovery-vault-loader
+spec:
+  template:
+    metadata:
+      labels:
+        app: hms-discovery-vault-loader
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "jobs-watcher"
+      containers:
+        - name: hms-discovery-vault-loader
+          env:
+            - name: VAULT_ADDR
+              value: "http://cray-vault.vault:8200"
+            - name: VAULT_SKIP_VERIFY
+              value: "true"
+            - name: VAULT_REDFISH_BMC_DEFAULTS
+              valueFrom:
+                secretKeyRef:
+                  name: cray-reds-credentials
+                  key: vault_redfish_defaults
+            - name: VAULT_REDFISH_SWITCH_DEFAULTS
+              valueFrom:
+                secretKeyRef:
+                  name: cray-reds-credentials
+                  key: vault_switch_defaults
+          image: {{ .Values.image.repository }}:{{ .Values.global.appVersion }}
+          command: ["vault_loader"]
+{{- end -}}

--- a/charts/v3.1/cray-hms-discovery/templates/sealedsecrets.yaml
+++ b/charts/v3.1/cray-hms-discovery/templates/sealedsecrets.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.vaultLoader.enabled }}
+{{- if index .Values "sealedSecrets" -}}
+{{- range $val := index .Values "sealedSecrets" }}
+{{- if $val.kind }}
+{{- if eq $val.kind "SealedSecret" }}
+---
+{{ toYaml $val }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/v3.1/cray-hms-discovery/values.yaml
+++ b/charts/v3.1/cray-hms-discovery/values.yaml
@@ -1,0 +1,36 @@
+---
+
+global:
+  appVersion: 1.18.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/hms-discovery
+  pullPolicy: IfNotPresent
+
+vaultLoader:
+  # Populate Vault (secrets/reds-creds) with system default River and SNMP credentials
+  enabled: true
+
+discovery:
+  logLevel: INFO  # PANIC, FATAL, ERROR, WARN, INFO, or DEBUG
+
+  # Power on mountain chassis slots that are off.
+  discoverMountain: true
+
+  # Identify unknown River BMCs that have been given a IP, and inform HSM.
+  discoverRiverWithDHCP: true
+
+  # Populate HSM with Management Node data form SLS
+  discoverManagementNodes: true
+
+  # Populate HSM with Management Virtual Node data form SLS
+  discoverManagementVirtualNodes: true
+
+  # Trigger a rediscover in HSM on redfish endpoints not in DiscoveryStarted/DiscoverStarted
+  rediscoverFailedRedfishEndpoints: true
+
+  # Populate Vault (secrets/hms-creds/) with per-switch credentials
+  populateManagementSwitchCredentials: true
+
+# Sealed secrets from customizations.yaml
+sealedSecrets: []

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -1,10 +1,16 @@
 ---
 # CSM Version is not really following semver.
 chartVersionToCSMVersion:
+  # Summary:
+  #   Chart Version: 2.0.0 <= x.y.z < 3.0.0, CSM Version: 1.2.0 <= x.y.z < 1.6.0
+  #   Chart Version: 3.0.0 <= x.y.z < 3.1.0, CSM Version: 1.6.0 <= x.y.z < 1.7.0
+  #   Chart Version: 3.1.0 <= x.y.z,         CSM Version: 1.7.0 <= x.y.z
+
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=2.1.0": "~1.2.0"
   ">=3.0.0": "~1.6.0"
+  ">=3.1.0": "~1.7.0" # 3.1.0 contains risky module/image updates that need long soak time for 1.7.0
 
 # The application version must be compliant to semantic versioning.
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -22,6 +28,7 @@ chartVersionToApplicationVersion:
   "3.0.0": "1.15.0"
   "3.0.1": "1.16.0"
   "3.0.2": "1.17.0"
+  "3.1.0": "1.18.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

#### Chart Changes

Adopted app version 1.18.0 for CSM 1.7.0 (helm chart 3.1.0)

#### App Changes

Updated image and module dependencies for security updates.

Made changes to docker-compose.devel.yaml file so that local testing functions again.  Converted to using single `secret` kv store and updated various VAULT_KEYPATH variables to point there.

### Issues and Related PRs

* Resolves [CASMHMS-6412](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6412)

### Testing

- Deployed on mug and watched logs to ensure no adverse logs were being made
- Suspended/unsuspended discovery job to ensure that continues to work
- Did local testing run of discovery after new hardware and ethernetInterfaces added.  All looked good in SMD and discovery logs sans lack of responses from BMCs since local dev testing docker compose file doesn't yet set up simulated BMCs with RIE.

Tested on:

* `mug`
* Local laptop

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Y
Were continuous integration tests run? Y/N   If not, Why? Y
Was an Upgrade tested?                 Y/N   If not, Why? Y 
Was a Downgrade tested?                Y/N   If not, Why? Y 

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated

### High Level Chart Changes

```diff
> diff -r charts/v3.0 charts/v3.1
diff -r charts/v3.0/cray-hms-discovery/Chart.yaml charts/v3.1/cray-hms-discovery/Chart.yaml
3c3
< version: 3.0.2
---
> version: 3.1.0
11c11
< appVersion: "1.17.0"
---
> appVersion: "1.18.0"
diff -r charts/v3.0/cray-hms-discovery/values.yaml charts/v3.1/cray-hms-discovery/values.yaml
4c4
<   appVersion: 1.17.0
---
>   appVersion: 1.18.0
```