### PR TITLE
CASMHMS-6391: Scaling and resource usage improvements

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.1] - 2025-05-09
+## [3.1.1] - 2025-05-08
 
 ### Updated
 

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,15 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-05-09
+
+### Updated
+
+- Updated image and module dependencies
+- Use hms-base for draining and closing request and response bodies
+- Fixed bug with jq use in runSnyk.sh
+- Internal tracking ticket: CASMHMS-6391
+
 ## [3.1.0] - 2025-03-14
 
 ### Security

--- a/charts/v3.1/cray-hms-discovery/Chart.yaml
+++ b/charts/v3.1/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 3.1.0
+version: 3.1.1
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.18.0"
+appVersion: "1.19.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-discovery/values.yaml
+++ b/charts/v3.1/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.18.0
+  appVersion: 1.19.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -29,6 +29,7 @@ chartVersionToApplicationVersion:
   "3.0.1": "1.16.0"
   "3.0.2": "1.17.0"
   "3.1.0": "1.18.0"
+  "3.1.1": "1.19.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated all module and image dependencies to latest versions.  The primary reason for this was to pick up some resource leak fixes to the HMS module dependencies.

Updated Go to v1.24.

Used hms-base APIs for explicitly draining and closing http request and response bodies.

Fixed a bug with jq use when running runSnyk.sh

Adopted app version 1.19.0 for CSM 1.7.0 (helm chart 3.1.1).

### Issues and Related PRs

* Resolves [CASMHMS-6391](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6391)

### Testing

Tested on:

* `mug`

Test description:

Upgraded to dev version of service.  Watched cron job log files to ensure nothing obvious was wrong.  There were no system tests to run on mug.  Local dev and pipeline tests all pass.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable