### PR TITLE
CASMHMS-6602: Update Discovery dependencies

### DIFF
--- a/.github/workflows/k8s_api_checker.yaml
+++ b/.github/workflows/k8s_api_checker.yaml
@@ -2,5 +2,5 @@ name: Kubernetes API Checker
 on: [push, pull_request, workflow_dispatch]
 jobs:
   k8s_api_checker:
-    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v3
+    uses: Cray-HPE/hms-build-chart-workflows/.github/workflows/k8s_api_checker.yaml@v4
     secrets: inherit

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated Alpine base image to pick up security fixes
 - Updated HMS image and Go module version dependencies
-- Updated k8s_api_checker.yaml from v3 to v4
+- Updated k8s_api_checker.yaml from v2 to v4
 - Internal tracking ticket: CASMHMS-6602
 
 ## [3.1.1] - 2025-05-08

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,15 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2] - 2025-09-26
+
+### Security
+
+- Updated Alpine base image to pick up security fixes
+- Updated HMS image and Go module version dependencies
+- Updated k8s_api_checker.yaml from v3 to v4
+- Internal tracking ticket: CASMHMS-6602
+
 ## [3.1.1] - 2025-05-08
 
 ### Updated

--- a/charts/v3.1/cray-hms-discovery/Chart.yaml
+++ b/charts/v3.1/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 3.1.1
+version: 3.1.2
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.19.0"
+appVersion: "1.20.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-discovery/values.yaml
+++ b/charts/v3.1/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.19.0
+  appVersion: 1.20.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -30,6 +30,7 @@ chartVersionToApplicationVersion:
   "3.0.2": "1.17.0"
   "3.1.0": "1.18.0"
   "3.1.1": "1.19.0"
+  "3.1.2": "1.20.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated Alpine base image from 3.21 to 3.22 to pick up security fixes.

Updated all of the HMS and Go module image dependencies.

Also updated chart build usage of k8s_api_checker.yaml workflow from v2 to v4 because we were having build issues.

Adopted app version 1.20.0 for CSM 1.7.1 (helm chart 3.1.2)

### Issues and Related PRs

* Resolves [CASMHMS-6602](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6602)

### Testing

Tested via pipeline execution of Integration tests.  Discovery does not have any CT tests to verify on real systems but I did deploy the service on mug just to verify no issues.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable