### PR TITLE
CASMHMS-6551: Updated hms-mountain-discovery image to v0.9.0

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.3] - 2025-11-06
+
+### Security
+
+- Updated hms-mountain-discovery image to v0.9.0
+- Internal tracking ticket: CASMHMS-6551
+
 ## [3.1.2] - 2025-09-26
 
 ### Security

--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,7 +5,7 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.3] - 2025-11-06
+## [3.1.3] - 2025-11-05
 
 ### Security
 

--- a/charts/v3.1/cray-hms-discovery/Chart.yaml
+++ b/charts/v3.1/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 3.1.2
+version: 3.1.3
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.20.0"
+appVersion: "1.21.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-discovery/values.yaml
+++ b/charts/v3.1/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.20.0
+  appVersion: 1.21.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -31,6 +31,7 @@ chartVersionToApplicationVersion:
   "3.1.0": "1.18.0"
   "3.1.1": "1.19.0"
   "3.1.2": "1.20.0"
+  "3.1.3": "1.21.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

Updated hms-mountain-discovery image to v0.9.0

Adopted app version 1.21.0 for CSM 1.7.1 (helm chart 3.1.3)

### Issues and Related PRs

* Resolves [CASMHMS-6551](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6551)

### Testing

Tested on:

* `mug`

- Deployed on mug and watched logs to ensure no adverse logs were being made
- Suspended/unsuspended discovery job to ensure that continues to work

### Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable