### PR TITLE
CASMHMS-6620 Update Discovery to point to latest SMD v2.45.0 image

### DIFF
--- a/changelog/v3.1.md
+++ b/changelog/v3.1.md
@@ -5,6 +5,13 @@ All notable changes to this project for v3.1.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.4] - 2025-12-08
+
+### Update
+
+- Updated hsm-discovery to point to latest SMD v2.45.0 image
+- Internal tracking ticket: CASMHMS-6620
+
 ## [3.1.3] - 2025-11-05
 
 ### Security

--- a/charts/v3.1/cray-hms-discovery/Chart.yaml
+++ b/charts/v3.1/cray-hms-discovery/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-discovery"
-version: 3.1.3
+version: 3.1.4
 description: "Kubernetes resources for cray-hms-discovery"
 home: "https://github.com/Cray-HPE/hms-discovery-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.21.0"
+appVersion: "1.22.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.1/cray-hms-discovery/values.yaml
+++ b/charts/v3.1/cray-hms-discovery/values.yaml
@@ -1,7 +1,7 @@
 ---
 
 global:
-  appVersion: 1.21.0
+  appVersion: 1.22.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-discovery

--- a/cray-hms-discovery.compatibility.yaml
+++ b/cray-hms-discovery.compatibility.yaml
@@ -32,6 +32,7 @@ chartVersionToApplicationVersion:
   "3.1.1": "1.19.0"
   "3.1.2": "1.20.0"
   "3.1.3": "1.21.0"
+  "3.1.4": "1.22.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

This PR updates go.mod to point to the latest SMD v2.45.0

Adopted app version 1.22.0 for CSM 1.7.2 (helm chart 3.1.4)

### Issues and Related PRs

* Resolves [CASMHMS-6620](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6620)
* Change will also be needed in `hms-discovery-charts`

### Testing

Tested on:

* `Mug`

#### Test Results:

Deployed latest unstable image on mug and watched if pods are coming up fine
Also validated logs to ensure no new issues are observed
```
Events:
  Type    Reason          Age   From               Message
  ----    ------          ----  ----               -------
  Normal  Scheduled       42s   default-scheduler  Successfully assigned services/hms-discovery-29421414-8w7qc to ncn-w005
....
  Normal  Created         38s   kubelet            Created container: istio-proxy
  Normal  Started         38s   kubelet            Started container istio-proxy
  Normal  Pulling         36s   kubelet            Pulling image "registry.local/artifactory.algol60.net/csm-docker/unstable/hms-discovery:1.22.0-20251208124139.574c6cc"
  Normal  Pulled          33s   kubelet            Successfully pulled image "registry.local/artifactory.algol60.net/csm-docker/unstable/hms-discovery:1.22.0-20251208124139.574c6cc" in 3.527s (3.527s including waiting). Image size: 61416335 bytes.
  Normal  Created         33s   kubelet            Created container: hms-discovery
  Normal  Started         33s   kubelet            Started container hms-discovery
```
[discovery_after_changes.log](https://github.com/user-attachments/files/24103493/discovery_after_changes.log)


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
